### PR TITLE
tweaking example to something that works on my local

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ function sayGoodbye (call, callback) {
 const implementation = {
   helloworld: {
     Greeter: {
-      sayHello,
-      sayGoodbye
+      SayHello: sayHello,
+      SayGoodbye: sayGoodbye
     }
   }
 }


### PR DESCRIPTION
I was getting an error using the implementation 

```
const implementation = {
    helloworld: {
	Greeter: {
	    sayHello,
            sayGoodbye
	}
    }
}
```

but 

```
const implementation = {
    helloworld: {
	Greeter: {
	    SayHello: sayHello,
        SayGoodbye: sayGoodbye
	}
    }
}
```

works.